### PR TITLE
Update linking-to-settings.md

### DIFF
--- a/src/linking-to-settings.md
+++ b/src/linking-to-settings.md
@@ -45,8 +45,8 @@ Refer to the [NHS login Interface Specification – Federation](https://nhsconne
 
 **Other environments:** 
 
-`https://settings.<ENV>.login.nhs.uk?asserted_login_identity=ewrffw...wfw`
+`https://settings.<ENV>.signin.nhs.uk?asserted_login_identity=ewrffw...wfw`
 
-e.g. `https://settings.sandpit.login.nhs.uk?asserted_login_identity=ewrffw...wfw`
+e.g. `https://settings.sandpit.signin.nhs.uk?asserted_login_identity=ewrffw...wfw`
 
 


### PR DESCRIPTION
In the case of the non-productive environments it seems that signin.nhs.uk is the correct subdomain, instead of the listed login.nhs.uk