### PR TITLE
Fix broken link on FIDO page

### DIFF
--- a/src/fido.md
+++ b/src/fido.md
@@ -21,4 +21,4 @@ Further information on this issue and other ways an app browser can support pass
 <li><a href="https://help.duo.com/s/article/8433?language=en_US">Guide to iOS and Android WebAuthn Support for Native Applications</a></li> 
 </ul>
 
-If your app does not support FIDO2 and you want to implement FIDO1, find out how we currently use FIDO on our <a href="http://localhost:8080/nhslogin/fido/">NHS login Interface Specification</a>.
+If your app does not support FIDO2 and you want to implement FIDO1, find out how we currently use FIDO on our <a href="/nhslogin/interface-spec-doc/">NHS login Interface Specification</a>.


### PR DESCRIPTION
I noticed this broken link on https://nhsconnect.github.io/nhslogin/fido/. due to https://github.com/nhsconnect/nhslogin/commit/586d035541a39704dc5a98623ebe5e943ac3c84e.

I have put the link back to what it was, and made it a relative link so that it works in local development and when hosted.

